### PR TITLE
Add Colors constants

### DIFF
--- a/src/constants/colors.re
+++ b/src/constants/colors.re
@@ -1,0 +1,26 @@
+module Colors = {
+    let black = "000000";
+    let darkGrey = "5B5B5B";
+    let mediumGrey = "E1E1E1";
+    let lightGrey = "EFEFEF";
+    let white = "FFFFFF";
+    let yellow = "FFD95E";
+    let tomato = "FF5B44";
+    let pink = "ED2C6E";
+    let fuchsia = "FF88F1";
+    let electricPurple = "BC01FF";
+    let darkPurple = "660C63";
+    let indigo = "2D2F7F";
+    let greyBlue = "5770D1";
+    let beachBlue = "2C77E5";
+    let skyBlue = "2ACFFF";
+    let bondiBlue = "00A3BD";
+    let eucalyptusGreen = "2CDA9D";
+    let lemonGreen = "C3D30E";
+    let green = "34C30A";
+    let amber = "FFCA00";
+    let red = "D0021B";
+};
+
+/* open Colors on the file */
+/* add color(`hex(Colors.yellow)) to the property*/


### PR DESCRIPTION
Adding Colors from Zeplin styleguide to use them as global

- Open Colors on the file
- add color(`hex(Colors.yellow)) to the property